### PR TITLE
Fix documentation url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 readme  = "README.md"
 homepage = "https://github.com/zisten/libr.rs"
 repository = "https://github.com/zisten/libr.rs.git"
-documentation = "http://zitsen.github.io/libr.rs/doc/libr/index.html"
+documentation = "http://zisten.github.io/libr.rs/libr/index.html"
 description = """
 A library for types and bingings to native C functions in libR,
 providing most of embedded-R and R math functions.


### PR DESCRIPTION
Fixes a typo in Cargo.toml with ducumentation URL error.
